### PR TITLE
Html serializer

### DIFF
--- a/src/Model/Schema.cs
+++ b/src/Model/Schema.cs
@@ -7,6 +7,7 @@ using Json.More;
 using OneOf;
 
 using StepWise.Prose.Collections;
+using StepWise.ProseMirror.Model;
 
 
 namespace StepWise.Prose.Model;
@@ -454,6 +455,20 @@ public class NodeSpec {
     /// backspacing or lifting, won't cross. An example of a node that
     /// should probably have this enabled is a table cell.</summary>
     public bool? Isolating { get; init; }
+    
+    /// Defines the default way a node of this type should be serialized
+    /// to DOM/HTML (as used by
+    /// [`DOMSerializer.fromSchema`](#model.DOMSerializer^fromSchema)).
+    /// Should return a DOM node or an [array
+    /// structure](#model.DOMOutputSpec) that describes one, with an
+    /// optional number zero (“hole”) in it to indicate where the node's
+    /// content should be inserted.
+    ///
+    /// For text nodes, the default is to create a text DOM node. Though
+    /// it is possible to create a serializer where text is rendered
+    /// differently, this is not supported inside the editor, so you
+    /// shouldn't override that in your text node spec.
+    public Func<Node, DomOutputSpec>? ToDom {get; init; }
 
     /// <summary>Defines the default way a node of this type should be serialized
     /// to a string representation for debugging (e.g. in error messages).</summary>
@@ -497,6 +512,12 @@ public class MarkSpec {
     /// <summary>Determines whether marks of this type can span multiple adjacent
     /// nodes when serialized to DOM/HTML. Defaults to true.</summary>
     public bool? Spanning { get; init; }
+    
+    /// Defines the default way marks of this type should be serialized
+    /// to DOM/HTML. When the resulting spec contains a hole, that is
+    /// where the marked content is placed. Otherwise, it is appended to
+    /// the top node.
+    public Func<Mark, bool, DomOutputSpec>? ToDom { get; init; }
 }
 
 /// <summary>Used to <see cref="NodeSpec.Attrs">define</see> attributes on nodes or

--- a/src/Model/ToDom.cs
+++ b/src/Model/ToDom.cs
@@ -1,0 +1,427 @@
+using System.Collections;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotNext.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using HtmlAgilityPack;
+using Json.More;
+using StepWise.Prose.Collections;
+using StepWise.Prose.Model;
+
+namespace StepWise.ProseMirror.Model;
+
+public class SerializeOptions
+{
+    public HtmlDocument? Document { get; set; }
+}
+
+public class DomSerializer
+{
+    public readonly Dictionary<string, Func<Node, DomOutputSpec>> Nodes;
+    public readonly Dictionary<string, Func<Mark, bool, DomOutputSpec>> Marks;
+    
+    public DomSerializer(Schema schema)
+    {
+        Nodes = NodesFromSchema(schema);
+        Marks = MarksFromSchema(schema);
+    }
+
+    public HtmlNode SerializeFragment(Fragment fragment, SerializeOptions? options, HtmlNode? target)
+    {
+        target ??= Utils.Doc(options?.Document).DocumentNode;
+
+        HtmlNode top = target;
+        List<(Mark, HtmlNode)> active = [];
+
+        fragment.ForEach((node, p, i) =>
+        {
+            if (active.Count > 0 || node.Marks.Count > 0)
+            {
+                int keep = 0;
+                int rendered = 0;
+
+                while (keep < active.Count && rendered < node.Marks.Count)
+                {
+                    Mark next = node.Marks[rendered];
+
+                    if (!Marks.ContainsKey(next.Type.Name))
+                    {
+                        rendered++;
+                        continue;
+                    }
+
+                    if (!next.Eq(active[keep].Item1) || next.Type.Spec.Spanning == false)
+                    {
+                        break;
+                    }
+
+                    keep++;
+                    rendered++;
+                }
+
+                while (keep < active.Count)
+                {
+                    top = active.pop().Item2;
+                }
+
+                while (rendered < node.Marks.Count)
+                {
+                    Mark add = node.Marks[rendered++];
+                    DomContent? markDom = SerializeMark(add, node.IsInline, options ?? new SerializeOptions());
+
+                    if (markDom is not null)
+                    {
+                        active.Add((add, top));
+                        top.AppendChild(markDom.Dom);
+                        top = markDom.Content ?? markDom.Dom;
+                    }
+                }
+            }
+
+            top.AppendChild(SerializeNodeInner(node, options));
+        });
+
+        return top;
+    }
+
+    private HtmlNode SerializeNodeInner(Node node, SerializeOptions? options)
+    {
+        DomContent domContent = Utils.RenderSpec(Utils.Doc(options?.Document), Nodes.Single(x => x.Key == node.Type.Name).Value(node), node.Attrs);
+
+        if (domContent.Content is not null)
+        {
+            if (node.IsLeaf)
+            {
+                throw new Exception("Content hole not allowed in a leaf node spec");
+            }
+            
+            SerializeFragment(node.Content, options, domContent.Content);
+        }
+
+        return domContent.Dom;
+    }
+
+    public HtmlNode SerializeNode(Node node, SerializeOptions options)
+    {
+        HtmlNode dom = SerializeNodeInner(node, options);
+
+        for (int i = node.Marks.Count - 1; i >= 0; i--)
+        {
+            DomContent? wrap = SerializeMark(node.Marks[i], node.IsInline, options);
+
+            if (wrap is not null)
+            {
+                (wrap.Content ?? wrap.Dom).AppendChild(dom);
+
+                dom = wrap.Dom;
+            }
+        }
+
+        return dom;
+    }
+
+    private DomContent? SerializeMark(Mark mark, bool inline, SerializeOptions options)
+    {
+        try
+        {
+            Func<Mark, bool, DomOutputSpec> toDom = Marks.Single(x => x.Key == mark.Type.Name).Value;
+            return Utils.RenderSpec(Utils.Doc(options.Document), toDom(mark, inline), mark.Attrs);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static DomContent RenderSpec(HtmlDocument doc, DomOutputSpec structure)
+    {
+        return Utils.RenderSpec(doc, structure, null);
+    }
+    public static DomContent RenderSpec(HtmlDocument doc, DomOutputSpec structure, Attrs? blockArraysIn)
+    {
+        return Utils.RenderSpec(doc, structure, blockArraysIn);
+    }
+
+    public static DomSerializer FromSchema(Schema schema)
+    {
+        return new DomSerializer(schema);
+        // return new DomSerializer(NodesFromSchema(schema), MarksFromSchema(schema));
+    }
+
+    static Dictionary<string, Func<Node, DomOutputSpec>> NodesFromSchema(Schema schema)
+    {
+        Dictionary<string, Func<Node, DomOutputSpec>> result = Utils.GatherToDom(schema.Nodes);
+
+        if (!result.ContainsKey("text"))
+        {
+            result["text"] = node => new DomOutputSpec(node.Text ?? "");
+        }
+
+        return result;
+    }
+    
+    static Dictionary<string, Func<Mark, bool, DomOutputSpec>> MarksFromSchema(Schema schema)
+    {
+        return Utils.GatherToDom(schema.Marks);
+    }
+}
+
+public static class Utils
+{
+    private static readonly Dictionary<Attrs, List<JsonNode>?> SuspiciousAttributeCache = new();
+    
+    public static HtmlDocument Doc(HtmlDocument? document)
+    {
+        return document ?? new HtmlDocument();
+    }
+
+    public static Dictionary<string, Func<Node, DomOutputSpec>> GatherToDom(Dictionary<string, NodeType> nodes)
+    {
+        Dictionary<string, Func<Node, DomOutputSpec>> result = [];
+
+        foreach (KeyValuePair<string, NodeType> kv in nodes)
+        {
+            Func<Node, DomOutputSpec>? toDom = kv.Value.Spec.ToDom;
+
+            if (toDom is not null)
+            {
+                result.Add(kv.Key, toDom);
+            }
+        }
+
+        return result;
+    }
+    public static Dictionary<string, Func<Mark, bool, DomOutputSpec>> GatherToDom(Dictionary<string, MarkType> marks)
+    {
+        Dictionary<string, Func<Mark, bool, DomOutputSpec>> result = [];
+
+        foreach (KeyValuePair<string, MarkType> kv in marks)
+        {
+            Func<Mark, bool, DomOutputSpec>? toDom = kv.Value.Spec.ToDom;
+
+            if (toDom is not null)
+            {
+                result.Add(kv.Key, toDom);
+            }
+        }
+
+        return result;
+    }
+
+    public static DomContent RenderSpec(HtmlDocument doc, DomOutputSpec structure, Attrs? blockArraysIn)
+    {
+        if (!string.IsNullOrEmpty(structure.StringValue))
+        {
+            return new DomContent(doc.CreateTextNode(structure.StringValue));
+        }
+
+        if (structure.DomNode is { NodeType: HtmlNodeType.Element })
+        {
+            return new DomContent(structure.DomNode);
+        }
+
+        if (structure.DomContent is { Dom.NodeType: HtmlNodeType.Element })
+        {
+            return structure.DomContent;
+        }
+
+        if (structure.ArrayValue is null)
+        {
+            throw new Exception("Invalid `structure` argument");
+        }
+
+        string tagName = structure.GetFirstArrayValue();
+
+        var suspicious = SuspiciousAttributes(blockArraysIn);
+        if (blockArraysIn is not null &&
+            suspicious is not null &&
+            suspicious.Any(sus => structure.ArrayValue.Any(str => str.Attributes == sus)))
+        {
+            throw new Exception("Using an array from an attribute object as a DOM spec. This may be an attempted cross site scripting attack.");
+        }
+
+        // Skip Namespace config, can't be done without a browser. Throw error instead.
+        if (tagName.Contains(' '))
+        {
+            throw new Exception("Tag names cannot have a space in them and XML Namespaces are not supported outside of a browser context.");
+        }
+
+        HtmlNode? contentDom = null;
+
+        HtmlNode dom = doc.CreateElement(tagName);
+
+        int start = 1;
+        
+        JsonNode? attrs = structure.ArrayValue[1].Attributes;
+
+        if (attrs is not null && attrs.GetValueKind() == JsonValueKind.Object && attrs["nodeType"] is null)
+        {
+            start = 2;
+            
+            foreach (KeyValuePair<string, JsonNode?> attribute in attrs.AsObject())
+            {
+                if (string.IsNullOrEmpty(attribute.Key)) continue;
+
+                if (attribute.Key.Contains(' '))
+                {
+                    throw new Exception("Attribute names cannot have a space in them and XML Namespaces are not supported outside of a browser context.");
+                }
+
+                dom.SetAttributeValue(attribute.Key, (attribute.Value?.AsValue().ToString()) ?? "");
+            }
+        }
+
+        for (int i = start; i < structure.ArrayValue.Count; i++)
+        {
+            JsonNode? child = structure.ArrayValue[i].Attributes;
+
+            if (child is not null && child.AsValue().TryGetValue(out int val) && val == 0)
+            {
+                if (i < structure.ArrayValue.Count - 1 || i > start)
+                {
+                    throw new Exception("Content hole must be the only child of its parent node");
+                }
+
+                return new DomContent(dom, dom);
+            }
+
+            if (structure.ArrayValue[i].Child is null)
+            {
+                throw new Exception("Error with array value");
+            }
+
+            DomContent inner = RenderSpec(doc, structure.ArrayValue[i].Child, blockArraysIn);
+
+            dom.AppendChild(inner.Dom);
+
+            if (inner.Content is null) continue;
+
+            if (contentDom is not null)
+            {
+                throw new Exception("Multiple content holes");
+            }
+
+            contentDom = inner.Content;
+        }
+
+        return new DomContent(dom, contentDom);
+    }
+    
+    private static List<JsonNode>? SuspiciousAttributes(Attrs? attrs)
+    {
+        if (attrs is null) return null;
+        
+        if(!SuspiciousAttributeCache.TryGetValue(attrs, out List<JsonNode>? value))
+        {
+            value = SuspiciousAttributesInner(attrs);
+            SuspiciousAttributeCache.Add(attrs, value);
+        }
+    
+        return value;
+    }
+    
+    private static List<JsonNode>? SuspiciousAttributesInner(Attrs attrs)
+    {
+        List<JsonNode>? result = null;
+    
+        void Scan(JsonNode? value)
+        {
+            if (value is not JsonArray) return;
+            
+            if (value.AsArray()[0]?.GetValueKind() == JsonValueKind.String)
+            {
+                result ??= [];
+                result.Add(value);
+            }
+            else
+            {
+                for (int i = 0; i < value.AsArray().Count; i++)
+                {
+                    Scan(value.AsArray()[i]);
+                }
+            }
+        }
+        
+        foreach (KeyValuePair<string,JsonNode?> kv in attrs)
+        {
+            Scan(kv.Value);
+        }
+
+        return result;
+    }
+}
+
+public class DomOutputSpec
+{
+    public string? StringValue { get; set; }
+    public List<ArraySpec>? ArrayValue { get; set; }
+    public HtmlNode? DomNode { get; set; }
+    public DomContent? DomContent { get; set; }
+
+    public DomOutputSpec(string value)
+    {
+        StringValue = value;
+    }
+
+    public DomOutputSpec(List<ArraySpec> array)
+    {
+        ArrayValue = array;
+    }
+
+    public DomOutputSpec(HtmlNode domNode)
+    {
+        DomNode = domNode;
+    }
+
+    public DomOutputSpec(DomContent domContent)
+    {
+        DomContent = domContent;
+    }
+
+    public string GetFirstArrayValue()
+    {
+        return (ArrayValue ?? throw new InvalidOperationException("Invalid array")).First().TagName ?? throw new InvalidOperationException("Invalid array, first entry is not a string");
+    }
+}
+
+public class DomContent(HtmlNode dom, HtmlNode? content = null)
+{
+    public HtmlNode Dom = dom;
+    public HtmlNode? Content = content;
+}
+
+public class ArraySpec
+{
+    public string? TagName { get; set; }
+    public JsonNode? Attributes { get; set; }
+    public DomOutputSpec Child { get; set; }
+}
+
+// public class ArraySpec
+// {
+//     public string? TagName { get; set; }
+//     public KeyValuePair<string, JsonNode?>? Attribute { get; set; }
+//     public DomOutputSpec? DomOutputSpec { get; set; }
+//     public bool? Hole { get; set; }
+//
+//     public ArraySpec(string value)
+//     {
+//         TagName = value;
+//     }
+//
+//     public ArraySpec(KeyValuePair<string, JsonNode?> attr)
+//     {
+//         Attribute = attr;
+//     }
+//
+//     public ArraySpec(DomOutputSpec value)
+//     {
+//         DomOutputSpec = value;
+//     }
+//
+//     public ArraySpec(bool hole)
+//     {
+//         Hole = hole;
+//     }
+// }

--- a/src/Model/ToDom.cs
+++ b/src/Model/ToDom.cs
@@ -243,7 +243,7 @@ public static class Utils
 
         int start = 1;
         
-        JsonNode? attrs = structure.ElementArray[1].Attributes;
+        JsonNode? attrs = structure.ElementArray.Count > 1 ? structure.ElementArray[1].Attributes : null;
 
         if (attrs is not null && attrs.GetValueKind() == JsonValueKind.Object && attrs["nodeType"] is null)
         {
@@ -258,6 +258,11 @@ public static class Utils
                     throw new Exception("Attribute names cannot have a space in them and XML Namespaces are not supported outside of a browser context.");
                 }
 
+                if (attribute.Key != "alt" && attribute.Value?.AsValue() == null)
+                {
+                    continue;
+                }
+                
                 dom.SetAttributeValue(attribute.Key, (attribute.Value?.AsValue().ToString()) ?? "");
             }
         }

--- a/src/Model/ToDom.cs
+++ b/src/Model/ToDom.cs
@@ -1,11 +1,6 @@
-using System.Collections;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using DotNext.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using HtmlAgilityPack;
-using Json.More;
 using StepWise.Prose.Collections;
 using StepWise.Prose.Model;
 
@@ -395,33 +390,20 @@ public class ArraySpec
 {
     public string? TagName { get; set; }
     public JsonNode? Attributes { get; set; }
-    public DomOutputSpec Child { get; set; }
-}
+    public DomOutputSpec? Child { get; set; }
 
-// public class ArraySpec
-// {
-//     public string? TagName { get; set; }
-//     public KeyValuePair<string, JsonNode?>? Attribute { get; set; }
-//     public DomOutputSpec? DomOutputSpec { get; set; }
-//     public bool? Hole { get; set; }
-//
-//     public ArraySpec(string value)
-//     {
-//         TagName = value;
-//     }
-//
-//     public ArraySpec(KeyValuePair<string, JsonNode?> attr)
-//     {
-//         Attribute = attr;
-//     }
-//
-//     public ArraySpec(DomOutputSpec value)
-//     {
-//         DomOutputSpec = value;
-//     }
-//
-//     public ArraySpec(bool hole)
-//     {
-//         Hole = hole;
-//     }
-// }
+    public ArraySpec(string tagName)
+    {
+        TagName = tagName;
+    }
+    
+    public ArraySpec(JsonNode attributes)
+    {
+        Attributes = attributes;
+    }
+    
+    public ArraySpec(DomOutputSpec child)
+    {
+        Child = child;
+    }
+}

--- a/src/SchemaBasic/SchemaBasic.cs
+++ b/src/SchemaBasic/SchemaBasic.cs
@@ -26,8 +26,8 @@ public static class BasicSchema {
             Group = "block",
             // ParseDOM = [ new() {tag = "p"}],
             ToDom = (Node node) => new DomOutputSpec([
-                new () { TagName = "p" },
-                new ArraySpec() { Attributes = JsonValue.Create(0) }
+                new ("p"),
+                new ArraySpec(JsonValue.Create(0))
             ])
         },
 
@@ -37,14 +37,17 @@ public static class BasicSchema {
             Group = "block",
             Defining = true,
             // ParseDOM = [ new() {tag = "blockquote"}],
-            // ToDOM()  new() { return blockquoteDOM }
+            ToDom = (Node node) => new DomOutputSpec([
+                new("blockquote"),
+                new ArraySpec(JsonValue.Create(0))
+            ])
         },
 
         // A horizontal rule (`<hr>`).
         ["horizontal_rule"] =  new() {
             Group = "block",
             // ParseDOM = [ new() {tag = "hr"}],
-            // toDOM()  new() { return hrDOM }
+            ToDom = (Node node) => new DomOutputSpec("hr")
         },
 
         // A heading textblock, with a `level` attribute that
@@ -62,6 +65,11 @@ public static class BasicSchema {
             //                       new() {tag = "h5", attrs =  new() {level = 5}},
             //                       new() {tag = "h6", attrs =  new() {level = 6}}],
             // toDOM(node)  new() { return ["h" + node.attrs.level, 0] }
+            
+            ToDom = (Node node) => new DomOutputSpec([
+                new( "h" + node.Attrs.GetValueOrDefault("level") ),
+                new ArraySpec( JsonValue.Create(0) )
+            ])
         },
 
         // A code listing. Disallows marks or non-text inline
@@ -74,7 +82,13 @@ public static class BasicSchema {
             Code = true,
             Defining = true,
             // ParseDOM = [ new() {tag = "pre", preserveWhitespace = "full"}],
-            // toDOM()  new() { return preDOM }
+            ToDom = (Node node) => new DomOutputSpec([
+                new( "pre" ),
+                new ArraySpec( new DomOutputSpec([
+                    new("code"),
+                    new ArraySpec( JsonValue.Create(0) )])
+                )
+            ])
         },
 
         // The text node.
@@ -102,6 +116,10 @@ public static class BasicSchema {
             //     }
             // }}],
             // toDOM(node)  new() { let  new() {src, alt, title} = node.attrs; return ["img",  new() {src, alt, title}] }
+            ToDom = (Node node) => new DomOutputSpec([
+                new ("img"),
+                new ArraySpec(new JsonObject(node.Attrs.Where(x => new List<string>() {"src", "alt", "title"}.Contains(x.Key)))),
+            ])
         },
 
         // A hard line break, represented in the DOM as `<br>`.
@@ -110,7 +128,7 @@ public static class BasicSchema {
             Group = "inline",
             Selectable = false,
             // ParseDOM = [ new() {tag = "br"}],
-            // toDOM()  new() { return brDOM }
+            ToDom = (Node node) => new DomOutputSpec("br")
         }
     };
 
@@ -131,6 +149,11 @@ public static class BasicSchema {
             //     return new() {href = dom.getAttribute("href"), title = dom.getAttribute("title")}
             // }}],
             // toDOM(node) new() { let new() {href, title} = node.attrs; return ["a", new() {href, title}, 0] }
+            ToDom = (mark, inline) => new DomOutputSpec([
+                new ("a"),
+                new ArraySpec(new JsonObject(mark.Attrs.Where(x => new List<string>() {"href", "title"}.Contains(x.Key)))),
+                new ArraySpec(JsonValue.Create(0))
+            ])
         },
 
         // An emphasis mark. Rendered as an `<em>` element. Has parse rules
@@ -141,9 +164,18 @@ public static class BasicSchema {
             //     new() {style = "font-style=italic"},
             //     new() {style = "font-style=normal", clearMark = m => m.type.name == "em"}
             // ],
-            // toDOM() new() { return emDOM }
+            ToDom = (Mark mark, bool inline) => new DomOutputSpec([
+                new ("em"),
+                new ArraySpec(JsonValue.Create(0))
+            ])
         },
-
+        ["italic"] = new() {
+            ToDom = (Mark mark, bool inline) => new DomOutputSpec([
+                new ("em"),
+                new ArraySpec(JsonValue.Create(0))
+            ])
+        },
+        
         // A strong mark. Rendered as `<strong>`, parse rules also match
         // `<b>` and `font-weight = bold`.
         ["strong"] = new() {
@@ -156,13 +188,26 @@ public static class BasicSchema {
             //     new() {style = "font-weight=400", clearMark = m => m.type.name == "strong"},
             //     new() {style = "font-weight", getAttrs = (value = string) => /^(bold(er)?|[5-9]\dnew() {2,})$/.test(value) && null},
             // ],
-            // toDOM() new() { return strongDOM }
+            ToDom = (Mark mark, bool inline) => new DomOutputSpec([
+                new ("strong"),
+                new ArraySpec(JsonValue.Create(0))
+            ])
+        },
+        
+        ["bold"] = new() {
+            ToDom = (Mark mark, bool inline) => new DomOutputSpec([
+                new ("strong"),
+                new ArraySpec(JsonValue.Create(0))
+            ])
         },
 
         // Code font mark. Represented as a `<code>` element.
         ["code"] = new() {
             // parseDOM = [new() {tag = "code"}],
-            // toDOM() new() { return codeDOM }
+            ToDom = (Mark mark, bool inline) => new DomOutputSpec([
+                new ("code"),
+                new ArraySpec(JsonValue.Create(0))
+            ])
         }
     };
 

--- a/src/SchemaBasic/SchemaBasic.cs
+++ b/src/SchemaBasic/SchemaBasic.cs
@@ -47,7 +47,9 @@ public static class BasicSchema {
         ["horizontal_rule"] =  new() {
             Group = "block",
             // ParseDOM = [ new() {tag = "hr"}],
-            ToDom = (Node node) => new DomOutputSpec("hr")
+            ToDom = (Node node) => new DomOutputSpec([
+                new ElementSpec("hr")
+            ])
         },
 
         // A heading textblock, with a `level` attribute that
@@ -104,7 +106,9 @@ public static class BasicSchema {
             Attrs =  new() {
                 ["src"] =  new() {},
                 ["alt"] =  new() {Default = null},
-                ["title"] =  new() {Default = null}
+                ["title"] =  new() {Default = null},
+                ["width"] = new() { Default = null },
+                ["height"] = new() { Default = null }
             },
             Group = "inline",
             Draggable = true,
@@ -118,7 +122,7 @@ public static class BasicSchema {
             // toDOM(node)  new() { let  new() {src, alt, title} = node.attrs; return ["img",  new() {src, alt, title}] }
             ToDom = (Node node) => new DomOutputSpec([
                 new ("img"),
-                new ElementSpec(new JsonObject(node.Attrs.Where(x => new List<string>() {"src", "alt", "title"}.Contains(x.Key)))),
+                new ElementSpec(new JsonObject(node.Attrs.Where(x => new List<string>() {"src", "alt", "title", "width", "height"}.Contains(x.Key)))),
             ])
         },
 
@@ -128,7 +132,9 @@ public static class BasicSchema {
             Group = "inline",
             Selectable = false,
             // ParseDOM = [ new() {tag = "br"}],
-            ToDom = (Node node) => new DomOutputSpec("br")
+            ToDom = (Node node) => new DomOutputSpec([
+                new ElementSpec("br")
+            ])
         }
     };
 
@@ -142,6 +148,8 @@ public static class BasicSchema {
         ["link"] = new() {
             Attrs = new() {
                 ["href"] = new() {},
+                ["target"] = new() { Default = null },
+                ["rel"] = new() { Default = null },
                 ["title"] = new() {Default = null}
             },
             Inclusive = false,
@@ -151,7 +159,7 @@ public static class BasicSchema {
             // toDOM(node) new() { let new() {href, title} = node.attrs; return ["a", new() {href, title}, 0] }
             ToDom = (mark, inline) => new DomOutputSpec([
                 new ("a"),
-                new ElementSpec(new JsonObject(mark.Attrs.Where(x => new List<string>() {"href", "title"}.Contains(x.Key)))),
+                new ElementSpec(new JsonObject(mark.Attrs.Where(x => new List<string>() {"href", "target", "rel", "title"}.Contains(x.Key)))),
                 new ElementSpec(JsonValue.Create(0))
             ])
         },

--- a/src/SchemaBasic/SchemaBasic.cs
+++ b/src/SchemaBasic/SchemaBasic.cs
@@ -1,6 +1,8 @@
+using System.Text.Json.Nodes;
 using StepWise.Prose.Collections;
 using StepWise.Prose.Model;
 using StepWise.Prose.SchemaList;
+using StepWise.ProseMirror.Model;
 
 
 namespace StepWise.Prose.SchemaBasic;
@@ -23,7 +25,10 @@ public static class BasicSchema {
             Content = "inline*",
             Group = "block",
             // ParseDOM = [ new() {tag = "p"}],
-            // ToDOM()  new() { return pDOM }
+            ToDom = (Node node) => new DomOutputSpec([
+                new () { TagName = "p" },
+                new ArraySpec() { Attributes = JsonValue.Create(0) }
+            ])
         },
 
         // A blockquote (`<blockquote>`) wrapping one or more blocks.

--- a/src/SchemaBasic/SchemaBasic.cs
+++ b/src/SchemaBasic/SchemaBasic.cs
@@ -27,7 +27,7 @@ public static class BasicSchema {
             // ParseDOM = [ new() {tag = "p"}],
             ToDom = (Node node) => new DomOutputSpec([
                 new ("p"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
 
@@ -39,7 +39,7 @@ public static class BasicSchema {
             // ParseDOM = [ new() {tag = "blockquote"}],
             ToDom = (Node node) => new DomOutputSpec([
                 new("blockquote"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
 
@@ -68,7 +68,7 @@ public static class BasicSchema {
             
             ToDom = (Node node) => new DomOutputSpec([
                 new( "h" + node.Attrs.GetValueOrDefault("level") ),
-                new ArraySpec( JsonValue.Create(0) )
+                new ElementSpec( JsonValue.Create(0) )
             ])
         },
 
@@ -84,9 +84,9 @@ public static class BasicSchema {
             // ParseDOM = [ new() {tag = "pre", preserveWhitespace = "full"}],
             ToDom = (Node node) => new DomOutputSpec([
                 new( "pre" ),
-                new ArraySpec( new DomOutputSpec([
+                new ElementSpec( new DomOutputSpec([
                     new("code"),
-                    new ArraySpec( JsonValue.Create(0) )])
+                    new ElementSpec( JsonValue.Create(0) )])
                 )
             ])
         },
@@ -118,7 +118,7 @@ public static class BasicSchema {
             // toDOM(node)  new() { let  new() {src, alt, title} = node.attrs; return ["img",  new() {src, alt, title}] }
             ToDom = (Node node) => new DomOutputSpec([
                 new ("img"),
-                new ArraySpec(new JsonObject(node.Attrs.Where(x => new List<string>() {"src", "alt", "title"}.Contains(x.Key)))),
+                new ElementSpec(new JsonObject(node.Attrs.Where(x => new List<string>() {"src", "alt", "title"}.Contains(x.Key)))),
             ])
         },
 
@@ -151,8 +151,8 @@ public static class BasicSchema {
             // toDOM(node) new() { let new() {href, title} = node.attrs; return ["a", new() {href, title}, 0] }
             ToDom = (mark, inline) => new DomOutputSpec([
                 new ("a"),
-                new ArraySpec(new JsonObject(mark.Attrs.Where(x => new List<string>() {"href", "title"}.Contains(x.Key)))),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(new JsonObject(mark.Attrs.Where(x => new List<string>() {"href", "title"}.Contains(x.Key)))),
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
 
@@ -166,13 +166,13 @@ public static class BasicSchema {
             // ],
             ToDom = (Mark mark, bool inline) => new DomOutputSpec([
                 new ("em"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
         ["italic"] = new() {
             ToDom = (Mark mark, bool inline) => new DomOutputSpec([
                 new ("em"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
         
@@ -190,14 +190,14 @@ public static class BasicSchema {
             // ],
             ToDom = (Mark mark, bool inline) => new DomOutputSpec([
                 new ("strong"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
         
         ["bold"] = new() {
             ToDom = (Mark mark, bool inline) => new DomOutputSpec([
                 new ("strong"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         },
 
@@ -206,7 +206,7 @@ public static class BasicSchema {
             // parseDOM = [new() {tag = "code"}],
             ToDom = (Mark mark, bool inline) => new DomOutputSpec([
                 new ("code"),
-                new ArraySpec(JsonValue.Create(0))
+                new ElementSpec(JsonValue.Create(0))
             ])
         }
     };

--- a/src/SchemaList/SchemaList.cs
+++ b/src/SchemaList/SchemaList.cs
@@ -1,5 +1,7 @@
+using System.Text.Json.Nodes;
 using StepWise.Prose.Collections;
 using StepWise.Prose.Model;
+using StepWise.ProseMirror.Model;
 
 
 namespace StepWise.Prose.SchemaList;
@@ -23,14 +25,26 @@ public static class ListSchema {
                 Attrs = new() {["order"] = new() {Default = new(1)}},
                 Content = "list_item+",
                 Group = listGroup,
+                ToDom = (node) => new DomOutputSpec([
+                    new("ol"),
+                    new ArraySpec(JsonValue.Create(0))
+                ])
             },
             ["bullet_list"] = new() {
                 Content = "list_item+",
-                Group = listGroup
+                Group = listGroup,
+                ToDom = (node) => new DomOutputSpec([
+                    new("ul"),
+                    new ArraySpec(JsonValue.Create(0))
+                ])
             },
             ["list_item"] = new() {
                 Content = itemContent,
-                Defining = true
+                Defining = true,
+                ToDom = (node) => new DomOutputSpec([
+                    new("li"),
+                    new ArraySpec(JsonValue.Create(0))
+                ])
             }
         };
     }

--- a/src/SchemaList/SchemaList.cs
+++ b/src/SchemaList/SchemaList.cs
@@ -27,7 +27,7 @@ public static class ListSchema {
                 Group = listGroup,
                 ToDom = (node) => new DomOutputSpec([
                     new("ol"),
-                    new ArraySpec(JsonValue.Create(0))
+                    new ElementSpec(JsonValue.Create(0))
                 ])
             },
             ["bullet_list"] = new() {
@@ -35,7 +35,7 @@ public static class ListSchema {
                 Group = listGroup,
                 ToDom = (node) => new DomOutputSpec([
                     new("ul"),
-                    new ArraySpec(JsonValue.Create(0))
+                    new ElementSpec(JsonValue.Create(0))
                 ])
             },
             ["list_item"] = new() {
@@ -43,7 +43,7 @@ public static class ListSchema {
                 Defining = true,
                 ToDom = (node) => new DomOutputSpec([
                     new("li"),
-                    new ArraySpec(JsonValue.Create(0))
+                    new ElementSpec(JsonValue.Create(0))
                 ])
             }
         };

--- a/src/StepWise.ProseMirror.csproj
+++ b/src/StepWise.ProseMirror.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNext" Version="4.12.4" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.63" />
     <PackageReference Include="Json.More.Net" Version="1.8.0" />
     <PackageReference Include="OneOf" Version="3.0.255" />
   </ItemGroup>


### PR DESCRIPTION
This is in relation to https://github.com/stepwisehq/prosemirror-dotnet/discussions/24 and is an attempt to port Prosemirror's DOM serialization. I've tried to stay as close to their code as possible, as it seemed that was how other parts of this repository were written. Since there is no actual DOM, this wasn't always possible and there are a couple comments mentioning such in the code.

HTML Agility Pack has been added to handle creating elements and outputting HTML strings.

This is one way only. I think taking HTML strings as input is a separate piece of work.

Thanks for the consideration!